### PR TITLE
Expose Payload CMS dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,6 @@ EMAIL_FROM="noreply@vetcee.org"
 # Contentful configuration
 CONTENTFUL_SPACE_ID="your-contentful-space-id"
 CONTENTFUL_ACCESS_TOKEN="your-contentful-access-token"
+
+# Payload CMS
+NEXT_PUBLIC_PAYLOAD_ADMIN_URL="http://localhost:3001/admin"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ## Setup
 
-1. Copy `.env.example` to `.env` and provide your own credentials.
+1. Copy `.env.example` to `.env` and provide your own credentials. Set `NEXT_PUBLIC_PAYLOAD_ADMIN_URL` to the URL of your Payload CMS admin panel.
 2. Install dependencies with `npm install`.
 3. Run the development server using `npm run dev`.
+
+Admin users can access the Payload CMS dashboard at `/cms`. The page embeds the admin interface defined by `NEXT_PUBLIC_PAYLOAD_ADMIN_URL` and is restricted to users with `AdminFull` or `AdminReadOnly` roles.

--- a/src/app/cms/[[...slug]]/page.tsx
+++ b/src/app/cms/[[...slug]]/page.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import { useEffect } from 'react'
+
+interface PageProps {
+  params: { slug?: string[] }
+}
+
+export default function CMSPage({ params }: PageProps) {
+  const { data: session, status } = useSession()
+  const router = useRouter()
+  const slug = params?.slug || []
+
+  const adminUrl = process.env.NEXT_PUBLIC_PAYLOAD_ADMIN_URL
+
+  useEffect(() => {
+    if (status === 'loading') return
+    if (status === 'unauthenticated') {
+      router.replace('/')
+      return
+    }
+    const roles = session?.user?.roles || []
+    const isAdmin = roles.includes('AdminFull') || roles.includes('AdminReadOnly')
+    if (!isAdmin) {
+      router.replace('/')
+    }
+  }, [status, session, router])
+
+  if (status === 'loading') {
+    return <div className="p-6 text-center">Loading...</div>
+  }
+
+  const roles = session?.user?.roles || []
+  const isAdmin = roles.includes('AdminFull') || roles.includes('AdminReadOnly')
+  if (!isAdmin) {
+    return <div className="p-6 text-center">Access denied.</div>
+  }
+
+  if (!adminUrl) {
+    return <div className="p-6 text-center">CMS URL not configured.</div>
+  }
+
+  const path = slug.length ? '/' + slug.join('/') : ''
+  const url = adminUrl + path
+
+  return (
+    <iframe src={url} className="w-full min-h-screen border-0" />
+  )
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -118,11 +118,11 @@ const Header: React.FC<HeaderProps> = ({ currentPath }) => {
               requiredRoles={adminRoles}
               requireAuth={true}
             />
-            <NavLink 
-              href="/cms" 
-              label="CMS" 
-              active={currentPath === '/cms'} 
-              requiredRoles={fullAdminRoles}
+            <NavLink
+              href="/cms"
+              label="CMS"
+              active={currentPath === '/cms'}
+              requiredRoles={adminRoles}
               requireAuth={true}
             />
             <NavLink 


### PR DESCRIPTION
## Summary
- add environment variable for Payload CMS
- link to CMS in README
- show CMS link to all admin users
- create `/cms` route that embeds the Payload admin

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities)*

------
https://chatgpt.com/codex/tasks/task_e_684609f4a1a88321b4d23fe37a70bc46