### PR TITLE
Address token security and session handling

### DIFF
--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -16,33 +16,12 @@ interface Notification {
   message: string;
 }
 
-export default function AdminUsers() {
+export default function AdminUsers({ users: initialUsers, isAdminFull }: { users: User[]; isAdminFull: boolean }) {
   const router = useRouter();
-  const [users, setUsers] = React.useState<User[]>([]);
-  const [isLoading, setIsLoading] = React.useState(true);
+  const [users, setUsers] = React.useState<User[]>(initialUsers);
+  const [isLoading, setIsLoading] = React.useState(false);
   const [notification, setNotification] = React.useState<Notification | null>(null);
   
-  React.useEffect(() => {
-    const fetchUsers = async () => {
-      try {
-        const response = await fetch('/api/admin/users');
-        if (response.ok) {
-          const data = await response.json();
-          setUsers(data.users || []);
-        }
-      } catch (error) {
-        console.error('Error fetching users:', error);
-        setNotification({
-          type: 'error',
-          message: 'Failed to load users. Please try again.'
-        });
-      } finally {
-        setIsLoading(false);
-      }
-    };
-    
-    fetchUsers();
-  }, []);
   
   const handleApprove = async (userId: string) => {
     try {
@@ -187,6 +166,7 @@ export default function AdminUsers() {
                         </button>
                       )}
                       
+                      {isAdminFull && (
                       <div className="relative group">
                         <button className="text-sm text-blue-600 hover:text-blue-800">
                           Manage Roles
@@ -268,6 +248,7 @@ export default function AdminUsers() {
                           </div>
                         </div>
                       </div>
+                      )}
                     </div>
                   </td>
                 </tr>

--- a/src/app/api/auth/callback/email/route.ts
+++ b/src/app/api/auth/callback/email/route.ts
@@ -101,11 +101,14 @@ export async function GET(request: NextRequest) {
     }
     
     // Create a session for the user
+    const isAdmin = user.roles.includes('AdminFull') || user.roles.includes('AdminReadOnly');
+    const sessionExpiry = new Date(Date.now() + (isAdmin ? 8 : 24) * 60 * 60 * 1000);
+
     const session = await prisma.session.create({
       data: {
         sessionToken: `${Math.random().toString(36).substring(2, 15)}${Math.random().toString(36).substring(2, 15)}`,
         userId: user.id,
-        expires: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24 hours
+        expires: sessionExpiry,
       },
     });
     
@@ -137,7 +140,7 @@ export async function GET(request: NextRequest) {
       httpOnly: true,
       path: '/',
       secure: process.env.NODE_ENV === 'production',
-      maxAge: 24 * 60 * 60, // 24 hours
+      maxAge: isAdmin ? 8 * 60 * 60 : 24 * 60 * 60,
     });
     
     return response;

--- a/src/app/api/auth/dev-magic-link/route.ts
+++ b/src/app/api/auth/dev-magic-link/route.ts
@@ -4,6 +4,9 @@ import { prisma } from '@/lib/prisma';
 export const runtime = 'nodejs';
 
 export async function GET(req: NextRequest) {
+  if (process.env.NODE_ENV !== 'development') {
+    return NextResponse.json({ error: 'Not Found' }, { status: 404 });
+  }
   const { searchParams } = new URL(req.url);
   const email = searchParams.get('email');
   if (!email) {

--- a/src/app/api/auth/invite/route.ts
+++ b/src/app/api/auth/invite/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { auth } from '@/lib/auth';
+import crypto from 'crypto';
 
 // Set runtime to nodejs to avoid Edge Runtime issues
 export const runtime = "nodejs";
@@ -32,11 +33,15 @@ export async function POST(req: NextRequest) {
     
     // Create verification token
     const token = crypto.randomUUID();
+    const hashedToken = crypto
+      .createHash('sha256')
+      .update(`${token}${process.env.NEXTAUTH_SECRET}`)
+      .digest('hex');
     const expires = new Date(Date.now() + 24 * 60 * 60 * 1000); // 24 hours
-    
+
     await prisma.verificationToken.create({
       data: {
-        token,
+        token: hashedToken,
         expires,
         email,
         role: 'Provider',

--- a/src/app/api/auth/register/complete/route.ts
+++ b/src/app/api/auth/register/complete/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { auth } from '@/lib/auth';
+import crypto from 'crypto';
 
 // Set runtime to nodejs to avoid Edge Runtime issues
 export const runtime = "nodejs";
@@ -37,10 +38,14 @@ export async function POST(req: NextRequest) {
     }
     
     // Verify token
+    const hashedToken = crypto
+      .createHash('sha256')
+      .update(`${token}${process.env.NEXTAUTH_SECRET}`)
+      .digest('hex');
     const verificationToken = await prisma.verificationToken.findFirst({
       where: {
         email,
-        token,
+        token: hashedToken,
         status: 'active',
         expires: {
           gt: new Date(),

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { auth } from '@/lib/auth';
+import crypto from 'crypto';
 
 // Set runtime to nodejs to avoid Edge Runtime issues
 export const runtime = "nodejs";
@@ -70,11 +71,15 @@ export async function POST(req: NextRequest) {
     
     // Create verification token
     const token = crypto.randomUUID();
+    const hashedToken = crypto
+      .createHash('sha256')
+      .update(`${token}${process.env.NEXTAUTH_SECRET}`)
+      .digest('hex');
     const expires = new Date(Date.now() + 24 * 60 * 60 * 1000); // 24 hours
-    
+
     await prisma.verificationToken.create({
       data: {
-        token,
+        token: hashedToken,
         expires,
         email,
         status: 'active',

--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -132,6 +132,7 @@ const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose, onEmailSent })
 
 
   const fetchMagicLink = async (email: string) => {
+    if (process.env.NODE_ENV !== 'development') return
     try {
       const res = await fetch(`/api/auth/dev-magic-link?email=${encodeURIComponent(email)}`)
       const data = await res.json()
@@ -340,7 +341,7 @@ const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose, onEmailSent })
                 ? "Sign in link sent to your email"
                 : "Account creation link sent to your email"}
             </p>
-            {magicLink && (
+            {process.env.NODE_ENV === 'development' && magicLink && (
               <p className="text-sm break-all">
                 <a className="underline" href={magicLink} target="_blank" rel="noopener noreferrer">Magic link</a>
               </p>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { getToken } from 'next-auth/jwt';
 
 // Configure CORS middleware for API routes
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   // Get the origin from the request headers
   const origin = request.headers.get('origin') || '';
   
@@ -10,6 +11,14 @@ export function middleware(request: NextRequest) {
   if (request.nextUrl.pathname.startsWith('/api/')) {
     // Create a new response
     const response = NextResponse.next();
+
+    // Check user status for protected routes (exclude NextAuth routes)
+    if (!request.nextUrl.pathname.startsWith('/api/auth')) {
+      const token = await getToken({ req: request, secret: process.env.NEXTAUTH_SECRET });
+      if (!token || token.status !== 'approved') {
+        return NextResponse.json({ error: 'User not approved' }, { status: 403 });
+      }
+    }
     
     // Set CORS headers
     response.headers.set('Access-Control-Allow-Origin', '*');


### PR DESCRIPTION
## Summary
- hash registration tokens and verify using the hashed value
- expire admin sessions after 8 hours
- block unapproved users in middleware
- hide dev magic links outside development
- pass user data to admin listing page instead of fetching on the client

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68467ff22d888321ab3a4dbef08ad159