### PR TITLE
Fix dashboard redirect after login

### DIFF
--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -224,7 +224,7 @@ const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose, onEmailSent })
           const result = await signIn('email', {
             email,
             redirect: false,
-            callbackUrl: window.location.pathname
+            callbackUrl: '/dashboard'
           })
           
           console.log('📧 [LOGIN MODAL] NextAuth result:', result)
@@ -285,7 +285,7 @@ const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose, onEmailSent })
         const result = await signIn('email', {
           email,
           redirect: false,
-          callbackUrl: window.location.pathname
+          callbackUrl: '/dashboard'
         })
         
         console.log('📧 [LOGIN MODAL] NextAuth result for new user:', result)


### PR DESCRIPTION
## Summary
- update LoginModal to always request a dashboard redirect

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities errors)*

------
https://chatgpt.com/codex/tasks/task_e_68474244c5a083219b13fd9a53966c25